### PR TITLE
Adding a bower file to make the analytics available to bower

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,8 @@
+{
+  "name": "chrome-platform-analytics",
+  "version": "0.1.0",
+  "main": "google-analytics-bundle.js",
+  "ignore": [],
+  "dependencies": {},
+  "devDependencies": {}
+}


### PR DESCRIPTION
Want to make the chrome-platform-analytics available to Bower (http://bower.io/).

Specifically I am trying to use yeoman (http://yeoman.io) to build a chrome packaged app and the yeoman process is based on using bower to manage dependencies.

The version seems to be the part that is most controversial since it doesn't appear that the chrome-platform-analytics has a version number that I saw. And there is an extra maintenance level with keeping that version number updated with each re-compile of the main google-analytics-bundle.js file.
