### PR TITLE
Ignore src in Bower

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -5,6 +5,7 @@
   "description": "Javascript Google Analytics (GA) client library for Chrome Platform Applications (and Extensions).",
   "license": "Apache 2.0",
   "ignore": [
+    "src"
   ],
   "dependencies": {
   },


### PR DESCRIPTION
We only need to pull down the built bundle in Bower. You might also want to
consider filling in some other Bower properties via `bower init`.
