### PR TITLE
Export createDimensionParam() and createMetricParam()

### DIFF
--- a/src/export_symbols.js
+++ b/src/export_symbols.js
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+goog.require('analytics');
 goog.require('analytics.EventBuilder');
 goog.require('analytics.HitTypes');
 goog.require('analytics.ParameterMap');
@@ -189,6 +190,13 @@ goog.object.forEach(
           'analytics.Parameters.' + name,
           value);
     });
+
+goog.exportSymbol(
+    'analytics.createDimensionParam',
+    analytics.createDimensionParam);
+goog.exportSymbol(
+    'analytics.createMetricParam',
+    analytics.createMetricParam);
 
 // EXTRAS...
 


### PR DESCRIPTION
Resolves #37.

Running the following command produces a minified js file that appears to have `analytics.createDimensionParam` and `analytics.createMetricParam` definitions.

```
closure-library/closure/bin/build/closurebuilder.py \
  --root=closure-library/ \
  --root=chrome-platform-analytics/src/ \
  --namespace="analytics.getService" \
  --namespace="analytics.filters.FilterBuilder" \
  --namespace="analytics.filters.EventLabelerBuilder" \
  --output_mode=compiled \
  --compiler_jar=compiler-v20151216.jar \
  --compiler_flags="--js=chrome-platform-analytics/src/export_symbols.js" \
  --compiler_flags="--compilation_level=ADVANCED_OPTIMIZATIONS" \
  > chrome-platform-analytics/compiled.js
```
